### PR TITLE
Fix typo in spell name in horizon.json

### DIFF
--- a/src/main/resources/data/otherworldapoth/affixes/armor/spell/horizon.json
+++ b/src/main/resources/data/otherworldapoth/affixes/armor/spell/horizon.json
@@ -1,6 +1,6 @@
 {
   "type": "otherworldapoth:spell_trigger",
-  "spell": "traveloptiocs:halberd_horizon",
+  "spell": "traveloptics:halberd_horizon",
   "trigger": "HURT",
   "target": "SELF",
   "values": {


### PR DESCRIPTION
Related:
Otherworld - v5 crashed. The logs have been uploaded to `mclo.gs`:
1. 1.20.1 [FORGE]
2. What launcher did you run Minecraft with? (e.g. CurseForge, ATLauncher, MultiMC, ...) Curse Forge
3. Have you changed the modpack in any way except mods? No
4. v5 Yeah. 
5. Have you ever gotten past the crash condition without crashing, or does the game always crash? Yes, I've been testing with almost 20% consistency. There seems to have a condition I don't know. It may be related to the existance of alshanex's familiars close to the player.
6. What steps cause the crash? Using Blood step.
### [latest.log](<https://mclo.gs/iyJr2un>)   |   [crash-2026-02-20_01.24.35-server.txt](<https://mclo.gs/HMRzV0t>)   |   [crash_assistant_app.log](<https://mclo.gs/9ql4h67>)   |   [modlist.txt](<https://mclo.gs/bz1x71r>)   |   CurseForge: skip launcher

### [Mod list changes](<https://mclo.gs/K4YyDe1>) on top of the modpack:
```ansi
[2;32m11[0m added, [2;31m0[0m removed, [2;34m3[0m updated.
```

I went into a little of the log, it seems to not be able to find something with the spell name "traveloptiocs". 
I don't know if it's the source of the problem, but it seems to be.